### PR TITLE
Convert v1 to v2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ dependencies = [
 name = "tag-my-tracks"
 version = "0.1.0"
 dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "id3 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quicli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "tmt"
 
 [dependencies]
 id3 = "0.3"
+failure = "0.1"
 quicli = "0.4"
 structopt = "0.2"
 walkdir = "2"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct Cli {
+    #[structopt(parse(from_os_str))]
+    pub path: PathBuf,
+
+    #[structopt(subcommand)]
+    pub cmd: Command,
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Command",
+    about = "Read or write fields from the ID3 Tags for a given path."
+)]
+pub enum Command {
+    #[structopt(
+        name = "read",
+        help = "Reads the requested fields from the ID3 tag(s) specified in the path"
+    )]
+    Read(ReadFields),
+
+    #[structopt(
+        name = "write",
+        help = "Writes the requested fields and their values to ID3v2.4 tag(s) specified in the path"
+    )]
+    Write(WriteFields),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct ReadFields {
+    #[structopt(long = "artist")]
+    pub artist: bool,
+
+    #[structopt(long = "album")]
+    pub album: bool,
+
+    #[structopt(long = "title")]
+    pub title: bool,
+
+    #[structopt(long = "year")]
+    pub year: bool,
+}
+
+#[derive(Debug, StructOpt)]
+pub struct WriteFields {
+    #[structopt(long = "artist")]
+    pub artist: Option<String>,
+
+    #[structopt(long = "album")]
+    pub album: Option<String>,
+
+    #[structopt(long = "title")]
+    pub title: Option<String>,
+
+    #[structopt(long = "year")]
+    pub year: Option<i32>,
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -42,6 +42,9 @@ pub struct ReadFields {
 
     #[structopt(long = "year")]
     pub year: bool,
+
+    #[structopt(long = "convert", help = "Automatically converts ID3v1 into ID3v2.4 instead of reporting an error")]
+    pub convert: bool,
 }
 
 #[derive(Debug, StructOpt)]
@@ -57,4 +60,7 @@ pub struct WriteFields {
 
     #[structopt(long = "year")]
     pub year: Option<i32>,
+
+    #[structopt(long = "convert", help = "Automatically converts ID3v1 into ID3v2.4 in writing process instead of reporting an error")]
+    pub convert: bool,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -43,7 +43,10 @@ pub struct ReadFields {
     #[structopt(long = "year")]
     pub year: bool,
 
-    #[structopt(long = "convert", help = "Automatically converts ID3v1 into ID3v2.4 instead of reporting an error")]
+    #[structopt(
+        long = "convert",
+        help = "Automatically converts ID3v1 into ID3v2.4 instead of reporting an error"
+    )]
     pub convert: bool,
 }
 
@@ -61,6 +64,9 @@ pub struct WriteFields {
     #[structopt(long = "year")]
     pub year: Option<i32>,
 
-    #[structopt(long = "convert", help = "Automatically converts ID3v1 into ID3v2.4 in writing process instead of reporting an error")]
+    #[structopt(
+        long = "convert",
+        help = "Automatically converts ID3v1 into ID3v2.4 in writing process instead of reporting an error"
+    )]
     pub convert: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,11 +65,6 @@ fn main() -> CliResult {
     if path.is_file() {
         process_file(&args, &path);
     } else {
-        // let mp3_files = get_all_files_in_directory(&args.path);
-        // for file in mp3_files.into_iter() {
-        //     let path = PathBuf::from(file);
-        //     process_file(&args, &path);
-        // }
         let mp3_paths = get_all_files_in_directory(&args.path);
         for path in mp3_paths.into_iter() {
             process_file(&args, &path);
@@ -78,7 +73,6 @@ fn main() -> CliResult {
 
     Ok(())
 }
-
 
 // Returns the file path if it's a .mp3 file or None.
 pub fn file_paths_mp3(dir_entry: &DirEntry) -> Option<PathBuf> {
@@ -190,7 +184,7 @@ pub fn process_file(args: &Cli, path: &PathBuf) {
                             Some(genre) => {
                                 println!("Genre: {:?}", genre);
                                 new_tag.set_genre(genre);
-                            },
+                            }
                             None => {}
                         }
 
@@ -202,16 +196,15 @@ pub fn process_file(args: &Cli, path: &PathBuf) {
                         match id3_v1_tag.track {
                             Some(track_num) => {
                                 new_tag.set_track(track_num as u32);
-                            },
+                            }
                             None => {}
                         }
 
-                        
                         println!("Comment: {:?}", id3_v1_tag.comment);
                         new_tag.write_to_path(&path, Version::Id3v24).unwrap();
                         println!("Converted Id3v1 tag to Id3v2.4")
-                    },
-                    Err(err) => println!("Error removing Id3v1 Tag from {:?}: {:?}", path, err)
+                    }
+                    Err(err) => println!("Error removing Id3v1 Tag from {:?}: {:?}", path, err),
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,63 +9,9 @@ use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 use walkdir::{DirEntry, WalkDir};
 
-#[derive(Debug, StructOpt)]
-pub struct Cli {
-    #[structopt(parse(from_os_str))]
-    path: PathBuf,
+pub mod cli;
 
-    #[structopt(subcommand)]
-    cmd: Command,
-}
-
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Command",
-    about = "Read or write fields from the ID3 Tags for a given path."
-)]
-pub enum Command {
-    #[structopt(
-        name = "read",
-        help = "Reads the requested fields from the ID3 tag(s) specified in the path"
-    )]
-    Read(ReadFields),
-
-    #[structopt(
-        name = "write",
-        help = "Writes the requested fields and their values to ID3v2.4 tag(s) specified in the path"
-    )]
-    Write(WriteFields),
-}
-
-#[derive(Debug, StructOpt)]
-pub struct ReadFields {
-    #[structopt(long = "artist")]
-    artist: bool,
-
-    #[structopt(long = "album")]
-    album: bool,
-
-    #[structopt(long = "title")]
-    title: bool,
-
-    #[structopt(long = "year")]
-    year: bool,
-}
-
-#[derive(Debug, StructOpt)]
-pub struct WriteFields {
-    #[structopt(long = "artist")]
-    artist: Option<String>,
-
-    #[structopt(long = "album")]
-    album: Option<String>,
-
-    #[structopt(long = "title")]
-    title: Option<String>,
-
-    #[structopt(long = "year")]
-    year: Option<i32>,
-}
+use cli::{Cli, Command, ReadFields, WriteFields};
 
 // TODO - Better error handling
 fn main() -> CliResult {
@@ -184,7 +130,6 @@ pub fn process_file(args: &Cli, path: &PathBuf) {
                 }
             }
 
-            // When the file already has an ID3v2+ tag.
             match &args.cmd {
                 Command::Write(tag_fields) => {
                     if tag_fields.artist.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,11 +113,11 @@ pub fn read_tag_with_args(fields: &ReadFields, path: &PathBuf) -> Result<(), Tag
 
             println!("----------------");
         }
-        Err(_err) => {
+        Err(err) => {
             let file = std::fs::File::open(path).unwrap();
             let id3_v1_tag = id3::v1::Tag::read_from(&file);
 
-            if !fields.convert {
+            if fields.convert {
                 match id3_v1_tag {
                     Ok(tag) => {
                         if fields.artist {
@@ -147,22 +147,9 @@ pub fn read_tag_with_args(fields: &ReadFields, path: &PathBuf) -> Result<(), Tag
                 }
             }
 
-            let mut new_tag = Tag::new();
-
-            match id3_v1_tag {
-                Ok(tag) => {
-                    new_tag.set_artist(tag.artist);
-                    new_tag.set_album(tag.album);
-                    new_tag.set_title(tag.title);
-                    new_tag.set_year(tag.year.parse::<i32>()?);
-                    new_tag.write_to_path(&path, Version::Id3v24)?;
-                }
-                Err(err) => {
-                    return Err(TagParseError::InvalidVersion2Tag(
-                        err.description.to_string(),
-                    ));
-                }
-            }
+            return Err(TagParseError::InvalidVersion2Tag(
+                err.description.to_string(),
+            ));
         }
     }
 
@@ -204,6 +191,8 @@ pub fn write_tag_with_args(fields: &WriteFields, path: &PathBuf) -> Result<(), T
             let id3_v1_tag = id3::v1::Tag::read_from(&file);
 
             let mut new_tag = Tag::new();
+
+            println!("Converting {:?} to Id3v2.4", &path);
 
             match id3_v1_tag {
                 Ok(tag) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,20 +114,36 @@ pub fn read_tag_with_args(fields: &ReadFields, path: &PathBuf) -> Result<(), Tag
 
             println!("----------------");
         }
-        Err(err) => {
+        Err(_err) => {
             if !fields.convert {
-                return Err(TagParseError::InvalidVersion2Tag(
-                    err.description.to_string(),
-                ));
+                
+                // Implement conversion logic here...
+                let file = std::fs::File::open(path).unwrap();
+                let id3_v1_tag = id3::v1::Tag::read_from(&file);
+
+                match id3_v1_tag {
+                    Ok(tag) => {
+                        println!("Artist: {}", tag.artist);
+                        println!("Album: {}", tag.album);
+                        println!("Title: {}", tag.title);
+                        println!("Year: {}", tag.year);
+                        println!("----------------");
+                        return Ok(());
+                    },
+                    Err(err) => {
+                        return Err(TagParseError::InvalidVersion2Tag(
+                            err.description.to_string(),
+                        ));
+                    }
+                }
+
+
             }
-            println!("Error converting file to ID3v2.4");
 
-            // Implement conversion logic here...
-            // let mut file = std::fs::File::open(path).unwrap();
-            // let id3_v1_tag = id3::v1::Tag::read_from(&file);
+            let file = std::fs::File::open(path).unwrap();
+            let id3_v1_tag = id3::v1::Tag::read_from(&file);
 
-            // dbg!(&id3_v1_tag);
-            // let mut new_tag = Tag::new();
+            dbg!(&id3_v1_tag);
         }
     }
 
@@ -166,7 +182,7 @@ pub fn write_tag_with_args(fields: &WriteFields, path: &PathBuf) -> Result<(), T
             }
             println!("Error converting file to ID3v2.4");
 
-            // Implement conversion logic here...
+            // //Implement conversion logic here...
             // let mut file = std::fs::File::open(path).unwrap();
             // let id3_v1_tag = id3::v1::Tag::read_from(&file);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
 extern crate id3;
+extern crate failure;
 extern crate quicli;
 extern crate structopt;
 extern crate walkdir;
 
+
 use id3::{Tag, Version};
+use failure::Error;
 use quicli::prelude::*;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
@@ -70,142 +73,187 @@ pub fn get_all_mp3_files_in_directory(directory: &Path) -> Vec<PathBuf> {
 
 */
 pub fn process_file(args: &Cli, path: &PathBuf) {
-    let possible_tag = Tag::read_from_path(&path);
+    // let id3v2_tag = Tag::read_from_path(&path);
 
-    match possible_tag {
-        Ok(mut tag) => match &args.cmd {
-            Command::Read(tag_fields) => read_tag_with_args(&tag, &tag_fields),
-            Command::Write(tag_fields) => write_tag_with_args(&mut tag, &tag_fields, &path),
+    match &args.cmd {
+        Command::Read(tag_fields) => read_tag_with_args(&tag_fields, &path),
+        Command::Write(tag_fields) => write_tag_with_args(&tag_fields, &path),
+    };
+
+    // match id3v2_tag {
+    //     Ok(mut tag) => match &args.cmd {
+    //         Command::Read(tag_fields) => read_tag_with_args(&tag, &tag_fields),
+    //         Command::Write(tag_fields) => write_tag_with_args(&mut tag, &tag_fields, &path),
+    //     },
+    //     Err(_err) => { // Can't parse an ID3v2.X tag from the path.
+    //         // Check if the error is instead related to parsing a ID3v1 tag.
+    //         let mut file = std::fs::File::open(path).unwrap();
+    //         let id3_v1_tag = id3::v1::Tag::read_from(&file);
+
+    //         dbg!(&id3_v1_tag);
+    //         let mut new_tag = Tag::new();
+
+    //         // Logic for converting / writing ID3v1 to ID3v2.4
+    //         if id3_v1_tag.is_ok() {
+    //             let id3_v1_tag = id3_v1_tag.unwrap();
+    //             let removed_tag = id3::v1::Tag::remove(&mut file);
+
+    //             match removed_tag {
+    //                 Ok(_) => {
+    //                     // Now we must convert from Id3v1 to Id3v2.4
+    //                     println!("Removed Id3v1 tag from {:?}", path);
+    //                     match id3_v1_tag.genre() {
+    //                         Some(genre) => {
+    //                             println!("Genre: {:?}", genre);
+    //                             new_tag.set_genre(genre);
+    //                         }
+    //                         None => {}
+    //                     }
+
+    //                     new_tag.set_artist(id3_v1_tag.artist);
+    //                     new_tag.set_title(id3_v1_tag.title);
+    //                     new_tag.set_album(id3_v1_tag.album);
+    //                     new_tag.set_year(id3_v1_tag.year.parse::<i32>().unwrap());
+
+    //                     match id3_v1_tag.track {
+    //                         Some(track_num) => {
+    //                             new_tag.set_track(track_num as u32);
+    //                         }
+    //                         None => {}
+    //                     }
+
+    //                     println!("Comment: {:?}", id3_v1_tag.comment);
+    //                     let convert_tag_result = new_tag.write_to_path(&path, Version::Id3v24);
+    //                     match convert_tag_result {
+    //                         Ok(_) => {
+    //                             println!("Successfully converted {:?} form v1 tag to v2.4", &path)
+    //                         }
+    //                         Err(err) => println!("Error converting from v1 tag to v2.4: {:?}", err),
+    //                     }
+
+    //                     println!("Converted Id3v1 tag to Id3v2.4")
+    //                 }
+
+    //                 Err(err) => println!("Error removing Id3v1 Tag from {:?}: {:?}", path, err),
+    //             }
+    //         }
+
+    //         // match &args.cmd {
+    //         //     Command::Write(tag_fields) => {
+    //         //         if tag_fields.artist.is_some() {
+    //         //             new_tag.set_artist(tag_fields.artist.clone().unwrap());
+    //         //         }
+
+    //         //         if tag_fields.album.is_some() {
+    //         //             new_tag.set_album(tag_fields.album.clone().unwrap());
+    //         //         }
+
+    //         //         if tag_fields.title.is_some() {
+    //         //             new_tag.set_title(tag_fields.title.clone().unwrap());
+    //         //         }
+
+    //         //         if tag_fields.year.is_some() {
+    //         //             new_tag.set_year(tag_fields.year.unwrap());
+    //         //         }
+
+    //         //         println!("Writing to {:?}", &path);
+    //         //         new_tag.write_to_path(&path, Version::Id3v24).unwrap();
+    //         //     }
+    //         //     _ => println!("Error parsing tag"),
+    //         // }
+    //     }
+    // }
+}
+
+#[derive(Debug, Fail)]
+pub enum TagParseError {
+    #[fail(display = "Couldn't parse to ID3v2")]
+    InvalidVersion2Tag,
+}
+
+pub fn read_tag_with_args(fields: &ReadFields, path: &PathBuf) -> Result<(), Error> {
+    let id3v2_tag = Tag::read_from_path(path);
+
+    match id3v2_tag {
+        Ok(tag) => {            
+            if fields.artist {
+                match tag.artist() {
+                    Some(artist) => println!("Artist: {}", artist),
+                    None => println!("Artist: --"),
+                }
+            }
+
+            if fields.album {
+                match tag.album() {
+                    Some(album) => println!("Album: {}", album),
+                    None => println!("Album: --"),
+                }
+            }
+
+            if fields.title {
+                match tag.title() {
+                    Some(title) => println!("Title: {}", title),
+                    None => println!("Title: --"),
+                }
+            }
+
+            if fields.year {
+                match tag.year() {
+                    Some(year) => println!("Year: {}", year),
+                    None => println!("Year: --"),
+                }
+            }
+
+            println!("----------------");
+
         },
-        Err(_err) => {
-            // Check if the error is instead related to parsing a ID3v1 tag.
-            let mut file = std::fs::File::open(path).unwrap();
-            let id3_v1_tag = id3::v1::Tag::read_from(&file);
-
-            dbg!(&id3_v1_tag);
-            let mut new_tag = Tag::new();
-
-            // Logic for converting / writing ID3v1 to ID3v2.4
-            if id3_v1_tag.is_ok() {
-                let id3_v1_tag = id3_v1_tag.unwrap();
-                let removed_tag = id3::v1::Tag::remove(&mut file);
-
-                match removed_tag {
-                    Ok(_) => {
-                        // Now we must convert from Id3v1 to Id3v2.4
-                        println!("Removed Id3v1 tag from {:?}", path);
-                        match id3_v1_tag.genre() {
-                            Some(genre) => {
-                                println!("Genre: {:?}", genre);
-                                new_tag.set_genre(genre);
-                            }
-                            None => {}
-                        }
-
-                        new_tag.set_artist(id3_v1_tag.artist);
-                        new_tag.set_title(id3_v1_tag.title);
-                        new_tag.set_album(id3_v1_tag.album);
-                        new_tag.set_year(id3_v1_tag.year.parse::<i32>().unwrap());
-
-                        match id3_v1_tag.track {
-                            Some(track_num) => {
-                                new_tag.set_track(track_num as u32);
-                            }
-                            None => {}
-                        }
-
-                        println!("Comment: {:?}", id3_v1_tag.comment);
-                        let convert_tag_result = new_tag.write_to_path(&path, Version::Id3v24);
-                        match convert_tag_result {
-                            Ok(_) => {
-                                println!("Successfully converted {:?} form v1 tag to v2.4", &path)
-                            }
-                            Err(err) => println!("Error converting from v1 tag to v2.4: {:?}", err),
-                        }
-
-                        println!("Converted Id3v1 tag to Id3v2.4")
-                    }
-
-                    Err(err) => println!("Error removing Id3v1 Tag from {:?}: {:?}", path, err),
-                }
+        Err(err) => {
+            if !fields.convert {
+                return Err(TagParseError::InvalidVersion2Tag);
             }
+            println!("Error converting file to ID3v2.4");
+            // let mut file = std::fs::File::open(path).unwrap();
+            // let id3_v1_tag = id3::v1::Tag::read_from(&file);
 
-            match &args.cmd {
-                Command::Write(tag_fields) => {
-                    if tag_fields.artist.is_some() {
-                        new_tag.set_artist(tag_fields.artist.clone().unwrap());
-                    }
-
-                    if tag_fields.album.is_some() {
-                        new_tag.set_album(tag_fields.album.clone().unwrap());
-                    }
-
-                    if tag_fields.title.is_some() {
-                        new_tag.set_title(tag_fields.title.clone().unwrap());
-                    }
-
-                    if tag_fields.year.is_some() {
-                        new_tag.set_year(tag_fields.year.unwrap());
-                    }
-
-                    println!("Writing to {:?}", &path);
-                    new_tag.write_to_path(&path, Version::Id3v24).unwrap();
-                }
-                _ => println!("Error parsing tag"),
-            }
+            // dbg!(&id3_v1_tag);
+            // let mut new_tag = Tag::new();
         }
     }
+
+    Ok(())
 }
 
-pub fn read_tag_with_args(tag: &Tag, command: &ReadFields) {
-    if command.artist {
-        match tag.artist() {
-            Some(artist) => println!("Artist: {}", artist),
-            None => println!("Artist: --"),
+pub fn write_tag_with_args(fields: &WriteFields, path: &PathBuf) -> Result<(), Error> {
+    let id3v2_tag = Tag::read_from_path(path);
+
+    match id3v2_tag {
+        Ok(tag) => { 
+            if fields.artist.is_some() {
+                tag.set_artist(fields.artist.clone().unwrap());
+            }
+
+            if fields.album.is_some() {
+                tag.set_album(fields.album.clone().unwrap());
+            }
+
+            if fields.title.is_some() {
+                tag.set_title(fields.title.clone().unwrap());
+            }
+
+            if fields.year.is_some() {
+                tag.set_year(fields.year.unwrap());
+            }
+
+            println!("Writing to {:?}", &path);
+            tag.write_to_path(&path, Version::Id3v24)?;
+        },
+        Err(err) => {
+            if !fields.convert {
+                return Err(TagParseError::InvalidVersion2Tag);
+            }
+            println!("Error converting file to ID3v2.4");
         }
     }
 
-    if command.album {
-        match tag.album() {
-            Some(album) => println!("Album: {}", album),
-            None => println!("Album: --"),
-        }
-    }
-
-    if command.title {
-        match tag.title() {
-            Some(title) => println!("Title: {}", title),
-            None => println!("Title: --"),
-        }
-    }
-
-    if command.year {
-        match tag.year() {
-            Some(year) => println!("Year: {}", year),
-            None => println!("Year: --"),
-        }
-    }
-
-    println!("----------------")
-}
-
-pub fn write_tag_with_args(tag: &mut Tag, command: &WriteFields, path: &PathBuf) {
-    if command.artist.is_some() {
-        tag.set_artist(command.artist.clone().unwrap());
-    }
-
-    if command.album.is_some() {
-        tag.set_album(command.album.clone().unwrap());
-    }
-
-    if command.title.is_some() {
-        tag.set_title(command.title.clone().unwrap());
-    }
-
-    if command.year.is_some() {
-        tag.set_year(command.year.unwrap());
-    }
-
-    println!("Writing to {:?}", &path);
-    tag.write_to_path(&path, Version::Id3v24).unwrap();
+    Ok(())
 }


### PR DESCRIPTION
For `.mp3` files which have ID3v1 tags, give the option to convert during reading. If convert isn't specified, an error will be returned. When writing, if convert isn't specified, it will fail. Otherwise it will only write the fields specified.

I may want to rethink this behavior. If the Id3v1 has lots of correct information and we only specify to write one field, we will lose all that info. We should probably have a separate command for converting the entire tag to Id3v2.4 and return messages per file that we can't write a newer tag to. 